### PR TITLE
fixing float to int conversion

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,9 +11,11 @@ The files are:
 - SteinbergCC121.transport.js (transport functions)
 
 When using Linux, the script should automaticly find and subscribe the controller. It can be necessary for other operating systems to manually choose the controller script and select the right MIDI-IN and MIDI-OUT devices in the Bitwig settings.
+There is an explanation what each knob and button does (assignment.pdf).  
 
 Changelog:
-- fixed missing typecast, causing script to cease working in bitwig 3.3
+Version 1.1:
+- fixed float to int conversion for volumeValue, causing script to cease working in bitwig 3.3
 
 Known issues: 
 

--- a/README.txt
+++ b/README.txt
@@ -12,9 +12,8 @@ The files are:
 
 When using Linux, the script should automaticly find and subscribe the controller. It can be necessary for other operating systems to manually choose the controller script and select the right MIDI-IN and MIDI-OUT devices in the Bitwig settings.
 
-Information:
-
-Script was tested in Linux Mint 18 64-bit with Bitwig 2 and uses API version 5. There is an explanation what each knob and button does (assignment.pdf).  
+Changelog:
+- fixed missing typecast, causing script to cease working in bitwig 3.3
 
 Known issues: 
 
@@ -24,4 +23,4 @@ However, the button function itself works fine - it is only the LEDs.
 About:
 
 Author: Philipp Winniewski
-Date: 22/06/2018
+Date: 18/12/2020

--- a/SteinbergCC121.channel.js
+++ b/SteinbergCC121.channel.js
@@ -59,8 +59,8 @@ function initChannel() {
     });
 
     trackBank.getChannel(0).volume().value().addValueObserver(function(volumeValue) {
-        var LSB = (volumeValue * 16383) % 128;
-        var MSB = (volumeValue * 16383) / 128;
+        var LSB = Math.trunc((volumeValue * 16383) % 128);
+        var MSB = Math.trunc((volumeValue * 16383) / 128);
         sendMidi(224, LSB, MSB);
     });
 

--- a/SteinbergCC121.control.js
+++ b/SteinbergCC121.control.js
@@ -83,7 +83,7 @@ var midiListeners;
 var isJogActive = false;
 
 // Company, product, script version, UUID, author
-host.defineController("Steinberg", "CC121", "1.0", "A1068940-6B61-11E8-B566-0800200C9A66", "Philipp Winniewski");
+host.defineController("Steinberg", "CC121", "1.1", "A1068940-6B61-11E8-B566-0800200C9A66", "Philipp Winniewski");
 host.defineMidiPorts(1, 1);
 // For Windows
 host.addDeviceNameBasedDiscoveryPair(["Steinberg CC121-1"], ["Steinberg CC121-1"]);


### PR DESCRIPTION
since bitwig 3.3 the original script was not working anymore. The issue was float values for volumeLevel in the div/mod calculation for MSB/LSB (see SteinbergCC121.channel.js) raising an error in sendMidi(). 
I think the bitwig API might have changed (maybe datatype of volumeLevel changed from int to float, or maybe an implicit typecast for arguments of sendMidi was removed), but to be honest, I did not check this.   